### PR TITLE
different package names for each platform

### DIFF
--- a/recipes/_gem.rb
+++ b/recipes/_gem.rb
@@ -27,7 +27,12 @@
 include_recipe 'build-essential'
 
 # libssl-dev required for SSL support in eventmachine
-package 'libssl-dev'
+case node['platform_family']
+when 'debian'
+  package 'libssl-dev'
+when 'rhel'
+  package 'openssl-devel'
+end
 
 include_recipe 'ruby_installer' if node['flapjack']['install_ruby']
 


### PR DESCRIPTION
This allows for flapjack to be installed as a gem on rhel systems because they use package name `openssl-devel` instead of `libssl-dev` 
